### PR TITLE
Take lock dir path from APP_CRONJOB_LOCKDIR env var

### DIFF
--- a/lib/App/Cronjob.pm
+++ b/lib/App/Cronjob.pm
@@ -69,7 +69,9 @@ sub run {
   $host    = hostname_long;
   $sender  = $opt->{sender} || sprintf '%s@%s', ($ENV{USER}||'cron'), $host;
 
-  my $lockfile = sprintf '/tmp/cronjob.%s',
+  my $lockdir = $ENV{APP_CRONJOB_LOCKDIR} || '/tmp';
+
+  my $lockfile = sprintf $lockdir.'/cronjob.%s',
                  $opt->{jobname} || md5_hex($subject);
 
   my $got_lock;


### PR DESCRIPTION
My lockfiles are best not placed in `/tmp`. I could have made this an option, but then it'd need to be on every job. Much easier to set the environment for the whole crontab.