### PR TITLE
Add -o switch to write output to file regardless of result

### DIFF
--- a/bin/cronjob
+++ b/bin/cronjob
@@ -17,6 +17,7 @@ App::Cronjob->run;
     -E --errors-only      do not send mail if exit code 0, even with output
     -f --sender           sender for message
     -j --jobname          job name; used for locking, if given
+    -o --output           append output to this file
     --lock                lock this job (defaults to true; --no-lock for off)
     --ignore-errors       error types to ignore (like: lock)
     --temp-ignore-lock-errors

--- a/lib/App/Cronjob.pm
+++ b/lib/App/Cronjob.pm
@@ -48,6 +48,7 @@ sub run {
      [ 'sender|f=s',    'sender for message',                                ],
      [ 'jobname|j=s',   'job name; used for locking, if given'               ],
      [ 'timeout=i',     "fail if the child isn't completed within n seconds" ],
+     [ 'output|o=s',    'append output to this file'                         ],
      [ 'ignore-errors=s@', 'error types to ignore (like: lock)'              ],
      [ 'temp-ignore-lock-errors=i',
                      'failure to lock only signals an error after this long' ],
@@ -152,6 +153,19 @@ sub run {
         time    => \$time_taken,
         output  => \$output,
       });
+    }
+
+    if ($opt->{output}) {
+      open my $out_fh, '>>', $opt->{output};
+      unless ($out_fh) {
+        $logger->log([
+          "failed to open output file '%s' for append: %s",
+          $opt->{output},
+          $!,
+        ]);
+      }
+      print $out_fh $output;
+      close $out_fh;
     }
 
     1;


### PR DESCRIPTION
Special request from @zomo, who would like to be able to see the output from the last run even if it ran fine.

Possible future enhancements include making the filename unique (append `$$`? allow a template?) and keeping last N, but this is the MVP.